### PR TITLE
Bug fix in Match::group()

### DIFF
--- a/POSIXRegex.cpp
+++ b/POSIXRegex.cpp
@@ -37,6 +37,9 @@ string Match::group(int group)
     if (group > pgroups.size())
         return "";
 
+    if (pgroups[group].start == -1 || pgroups[group].end == -1)
+        return "";
+    
     return match.substr(pgroups[group].start, pgroups[group].end - pgroups[group].start);
 }
 


### PR DESCRIPTION
Return empty string if start index or end index of group is -1